### PR TITLE
Corrupted snap root inode

### DIFF
--- a/src/mds/SnapRealm.cc
+++ b/src/mds/SnapRealm.cc
@@ -596,6 +596,9 @@ void SnapRealm::merge_to(SnapRealm *newparent)
 {
   if (!newparent)
     newparent = parent;
+  if (!newparent)
+    dout(0) << "snap info on root inode is corrupted. Try running cephfs-data-scan init to fix it" << dendl;
+	
   dout(10) << "merge to " << *newparent << " on " << *newparent->inode << dendl;
 
   ceph_assert(open_past_children.empty());


### PR DESCRIPTION
mds

Improving the output in a situation in which there is a corrupted root inode that can be fixed with data-scan init

Gustavo Tonini